### PR TITLE
Update rlm_amqp.c

### DIFF
--- a/build/rlm_amqp/rlm_amqp.c
+++ b/build/rlm_amqp/rlm_amqp.c
@@ -29,8 +29,8 @@ RCSID("$Id$")
 #include <freeradius-devel/rad_assert.h>
 
 #include <json-c/json.h>
-#include <amqp.h>
-#include <amqp_tcp_socket.h>
+#include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/tcp_socket.h>
 #include "utils.h"
 
 #include <sys/time.h>


### PR DESCRIPTION
amqp.h and amqp_tcp_socket.h is deprecated in rabbitmq-c 0.13.0